### PR TITLE
add reader support

### DIFF
--- a/sozipfile/sozipfile.py
+++ b/sozipfile/sozipfile.py
@@ -367,6 +367,7 @@ class ZipInfo (object):
         'file_size',
         '_raw_time',
         'sozip_index',
+        'chunk_size',
     )
 
     def __init__(self, filename="NoName", date_time=(1980,1,1,0,0,0)):
@@ -412,6 +413,7 @@ class ZipInfo (object):
         # header_offset         Byte offset to the file header
         # CRC                   CRC-32 of the uncompressed file
         self.sozip_index = None
+        self.chunk_size = None
 
     def __repr__(self):
         result = ['<%s filename=%r' % (self.__class__.__name__, self.filename)]
@@ -618,6 +620,7 @@ class ZipInfo (object):
             self.sozip_index = [x for x in struct.unpack('<' + 'I' * numChunks, fp.read(offsetSize * numChunks))]
         else:
             self.sozip_index = [x for x in struct.unpack('<' + 'Q' * numChunks, fp.read(offsetSize * numChunks))]
+        self.chunk_size = chunkSize
 
         fp.seek(cur_pos)
         return True
@@ -915,6 +918,10 @@ class ZipExtFile(io.BufferedIOBase):
                 self._orig_file_size = zipinfo.file_size
                 self._orig_start_crc = self._running_crc
                 self._seekable = True
+                self._sozip_index = zipinfo.sozip_index
+                self._chunk_size = zipinfo.chunk_size
+                # need a flag to disable CRC check when seeked
+                self._ignore_crc = False
         except AttributeError:
             pass
 
@@ -1027,7 +1034,7 @@ class ZipExtFile(io.BufferedIOBase):
 
     def _update_crc(self, newdata):
         # Update the CRC using the given data.
-        if self._expected_crc is None:
+        if self._expected_crc is None or self._ignore_crc:
             # No need to compute the CRC if we don't have a reference value
             return
         self._running_crc = crc32(newdata, self._running_crc)
@@ -1165,6 +1172,28 @@ class ZipExtFile(io.BufferedIOBase):
             # Just move the _offset index if the new position is in the _readbuffer
             self._offset = buff_offset
             read_offset = 0
+        elif self._sozip_index is not None and self._decrypter is None:
+            # Determine chunk index and distance to chunk
+            chunk_index, read_offset = divmod(new_pos, self._chunk_size)
+            if chunk_index > len(self._sozip_index):
+                chunk_index = len(self._sozip_index)
+                read_offset = self._chunk_size
+            # The offset of the first chunk (=0) is not part of the sozip index
+            if chunk_index > 0:
+                chunk_offset = self._sozip_index[chunk_index - 1]
+                # When seeked, do not compute CRC
+                self._ignore_crc = True
+            else:
+                chunk_offset = 0
+                self._ignore_crc = False
+            self._fileobj.seek(self._orig_compress_start + chunk_offset)
+            self._running_crc = self._orig_start_crc
+            self._compress_left = self._orig_compress_size - chunk_offset
+            self._left = self._orig_file_size - chunk_index*self._chunk_size
+            self._readbuffer = b''
+            self._offset = 0
+            self._decompressor = _get_decompressor(self._compress_type)
+            self._eof = False
         elif read_offset < 0:
             # Position is before the current position. Reset the ZipExtFile
             self._fileobj.seek(self._orig_compress_start)
@@ -1582,6 +1611,9 @@ class ZipFile:
             total = (total + sizeCentralDir + centdir[_CD_FILENAME_LENGTH]
                      + centdir[_CD_EXTRA_FIELD_LENGTH]
                      + centdir[_CD_COMMENT_LENGTH])
+            if x.compress_type != ZIP_STORED:
+                # If compressed, set sozip attributes if available
+                x.is_sozip_optimized(self)
 
             if self.debug > 2:
                 print("total", total)

--- a/sozipfile/sozipfile.py
+++ b/sozipfile/sozipfile.py
@@ -1611,9 +1611,6 @@ class ZipFile:
             total = (total + sizeCentralDir + centdir[_CD_FILENAME_LENGTH]
                      + centdir[_CD_EXTRA_FIELD_LENGTH]
                      + centdir[_CD_COMMENT_LENGTH])
-            if x.compress_type != ZIP_STORED:
-                # If compressed, set sozip attributes if available
-                x.is_sozip_optimized(self)
 
             if self.debug > 2:
                 print("total", total)
@@ -1657,7 +1654,9 @@ class ZipFile:
         if info is None:
             raise KeyError(
                 'There is no item named %r in the archive' % name)
-
+        if info.compress_type != ZIP_STORED and info.sozip_index is None:
+            # If compressed, set sozip attributes if available
+            info.is_sozip_optimized(self)
         return info
 
     def setpassword(self, pwd):

--- a/tests/test_reading.py
+++ b/tests/test_reading.py
@@ -1,0 +1,111 @@
+import tempfile
+import unittest
+import pathlib
+import zipfile
+
+try:
+    from sozipfile import sozipfile
+except ImportError:
+    import sys
+
+    sys.path.append("../sozipfile")
+    from sozipfile import sozipfile
+
+
+class TestReading(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # create temporary directory
+        cls._tempdir = tempfile.TemporaryDirectory(prefix="test-sozipfile-")
+        cls.addClassCleanup(cls._tempdir.cleanup)
+        cls.temp_path = pathlib.Path(cls._tempdir.name)
+        # create archives with sozipfile and zipfile
+        cls.sozip_path = cls.temp_path / "soarchive.zip"
+        cls.content = "\n".join(f"{number:04d}" for number in range(5000)).encode()
+        cls.chunk_size = 1024
+        with sozipfile.ZipFile(
+            cls.sozip_path,
+            "w",
+            compression=sozipfile.ZIP_DEFLATED,
+            chunk_size=cls.chunk_size,
+        ) as myzip:
+            myzip.writestr("numbers.txt", cls.content)
+            # write an uncompressed file
+            myzip.writestr(
+                "hello.txt", "Hello World!", compress_type=sozipfile.ZIP_STORED
+            )
+        # create conventional zip archive
+        cls.zip_path = cls.temp_path / "archive.zip"
+        with zipfile.ZipFile(
+            cls.zip_path, "w", compression=zipfile.ZIP_DEFLATED
+        ) as myzip:
+            myzip.writestr("numbers.txt", cls.content)
+
+    def test_read_conventional_zip_with_sozipfile(self):
+        with sozipfile.ZipFile(self.zip_path, mode="r") as myzip:
+            zinfo = myzip.getinfo("numbers.txt")
+            self.assertIsNone(zinfo.sozip_index)
+            with myzip.open(zinfo) as file:
+                content = file.read()
+            self.assertEqual(content, self.content)
+
+    def test_read_seek_optimized_zip_with_sozipfile(self):
+        with sozipfile.ZipFile(self.sozip_path, mode="r") as myzip:
+            # read un-indexed file
+            zinfo = myzip.getinfo("hello.txt")
+            self.assertIsNone(zinfo.sozip_index)
+            with myzip.open(zinfo) as file:
+                hello = file.read()
+            self.assertEqual(hello, b"Hello World!")
+            # read indexed file
+            zinfo = myzip.getinfo("numbers.txt")
+            self.assertIsNotNone(zinfo.sozip_index)
+            with myzip.open(zinfo) as file:
+                content = file.read()
+        self.assertEqual(content, self.content)
+
+    def test_seek_and_read(self):
+        with sozipfile.ZipFile(self.sozip_path, mode="r") as myzip:
+            with myzip.open("numbers.txt") as file:
+                file.seek(2000)
+                content = file.read(1500)
+        self.assertEqual(content, self.content[2000:3500])
+
+    def test_seek_before_file(self):
+        with sozipfile.ZipFile(self.sozip_path, mode="r") as myzip:
+            with myzip.open("numbers.txt") as file:
+                file.seek(-2 * self.chunk_size)
+                content = file.read(100)
+        self.assertEqual(content, self.content[:100])
+        # check that zipfile behaves the same
+        with zipfile.ZipFile(self.sozip_path, mode="r") as myzip:
+            with myzip.open("numbers.txt") as file:
+                file.seek(-2 * self.chunk_size)
+                content = file.read(100)
+        self.assertEqual(content, self.content[:100])
+
+    def test_seek_beyond_filesize(self):
+        with sozipfile.ZipFile(self.sozip_path, mode="r") as myzip:
+            with myzip.open("numbers.txt") as file:
+                file.seek(len(self.content) + 500)
+                content = file.read(100)
+        self.assertEqual(content, b"")
+        # check that zipfile behaves the same
+        with zipfile.ZipFile(self.sozip_path, mode="r") as myzip:
+            with myzip.open("numbers.txt") as file:
+                file.seek(len(self.content) + 500)
+                content = file.read(100)
+        self.assertEqual(content, b"")
+
+    def test_reactivate_crc_check(self):
+        with sozipfile.ZipFile(self.sozip_path, mode="r") as myzip:
+            zinfo = myzip.getinfo("numbers.txt")
+            zinfo.CRC += 1
+            with myzip.open("numbers.txt") as file:
+                file.seek(-500, 2)
+                file.read()  # no exception
+                file.seek(0)
+                with self.assertRaisesRegex(
+                    sozipfile.BadZipFile, r"Bad CRC-32 for file .*"
+                ):
+                    file.read()


### PR DESCRIPTION
This PR adds reader support using the sozip index.

When using the sozip index, we cannot compute the CRC value. Therefore, this implementation disables this check silently.
I think this is fine, but strictly speaking this would be a backward incompatibility.